### PR TITLE
Use a callback to provide a custom viewport to render the page instead of target height and width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-pdfjs",
-	"version": "0.3.0-alpha.0",
+	"version": "0.3.0-alpha.1",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-pdfjs",
-	"version": "0.2.0",
+	"version": "0.3.0-alpha.0",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-pdfjs",
-	"version": "0.3.0-alpha.2",
+	"version": "0.3.0",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-pdfjs",
-	"version": "0.3.0-alpha.1",
+	"version": "0.3.0-alpha.2",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",

--- a/src/lib/PDFViewer/Page.svelte
+++ b/src/lib/PDFViewer/Page.svelte
@@ -11,28 +11,11 @@ Render a page from a PDF document. Must be a child of a `Document` component.
 
 	type MultipleOf90 = 0 | 90 | 180 | 270;
 
-	function get_viewport(
+	function default_get_viewport(
 		page: PDFPageProxy,
-		height: number,
-		width: number,
-		scale: number,
-		rotation: MultipleOf90
-	) {
-		const tmp_viewport = page.getViewport({ scale: 1, rotation });
-		if (width || height) {
-			let scale = height / tmp_viewport.height;
-			if (width) {
-				scale = width / tmp_viewport.width;
-			}
-			return page.getViewport({
-				scale,
-				rotation,
-			});
-		}
-		return page.getViewport({
-			scale,
-			rotation,
-		});
+		options: { scale: number; rotation: MultipleOf90 }
+	): PageViewport {
+		return page.getViewport(options);
 	}
 </script>
 
@@ -52,16 +35,16 @@ Render a page from a PDF document. Must be a child of a `Document` component.
 	 * @default {1}
 	 */
 	export let zoomLevel: number = 1;
-	/**
-	 * Override the height to render the page at.
-	 * If both `targetHeight` and `targetWidth` are provided, then targetWidth takes precedence.
-	 */
-	export let targetHeight: number = undefined;
-	/**
-	 * Override the width to render the page at.
-	 * If both `targetHeight` and `targetWidth` are provided, then targetWidth takes precedence.
-	 */
-	export let targetWidth: number = undefined;
+	// /**
+	//  * Override the height to render the page at.
+	//  * If both `targetHeight` and `targetWidth` are provided, then targetWidth takes precedence.
+	//  */
+	// export let targetHeight: number = undefined;
+	// /**
+	//  * Override the width to render the page at.
+	//  * If both `targetHeight` and `targetWidth` are provided, then targetWidth takes precedence.
+	//  */
+	// export let targetWidth: number = undefined;
 	/**
 	 * Rotate the page by a multiple of 90 degrees.
 	 * @default {0}
@@ -72,6 +55,12 @@ Render a page from a PDF document. Must be a child of a `Document` component.
 	 * @default {false}
 	 */
 	export let renderTextLayer: boolean = false;
+
+	/**
+	 * A callback invoked with the current page used to determine the viewport.
+	 * Use this if you need something more complicated than the default based on scale.
+	 */
+	export let getViewport: (page: PDFPageProxy) => PageViewport = undefined;
 
 	/* <========================================================================================> */
 
@@ -92,7 +81,11 @@ Render a page from a PDF document. Must be a child of a `Document` component.
 	/* <========================================================================================> */
 
 	$: if ($current_doc) $current_doc.getPage(pageNumber).then((p) => (page = p));
-	$: if (page) viewport = get_viewport(page, targetHeight, targetWidth, zoomLevel, rotation);
+
+	$: _get_viewport =
+		getViewport ?? ((p: PDFPageProxy) => default_get_viewport(p, { scale: zoomLevel, rotation }));
+
+	$: if (page) viewport = _get_viewport(page);
 </script>
 
 <svelte:component

--- a/src/lib/PDFViewer/Page.svelte
+++ b/src/lib/PDFViewer/Page.svelte
@@ -34,17 +34,7 @@ Render a page from a PDF document. Must be a child of a `Document` component.
 	 * The scale to show the PDF at.
 	 * @default {1}
 	 */
-	export let zoomLevel: number = 1;
-	// /**
-	//  * Override the height to render the page at.
-	//  * If both `targetHeight` and `targetWidth` are provided, then targetWidth takes precedence.
-	//  */
-	// export let targetHeight: number = undefined;
-	// /**
-	//  * Override the width to render the page at.
-	//  * If both `targetHeight` and `targetWidth` are provided, then targetWidth takes precedence.
-	//  */
-	// export let targetWidth: number = undefined;
+	export let scale: number = 1;
 	/**
 	 * Rotate the page by a multiple of 90 degrees.
 	 * @default {0}
@@ -83,7 +73,7 @@ Render a page from a PDF document. Must be a child of a `Document` component.
 	$: if ($current_doc) $current_doc.getPage(pageNumber).then((p) => (page = p));
 
 	$: _get_viewport =
-		getViewport ?? ((p: PDFPageProxy) => default_get_viewport(p, { scale: zoomLevel, rotation }));
+		getViewport ?? ((p: PDFPageProxy) => default_get_viewport(p, { scale, rotation }));
 
 	$: if (page) viewport = _get_viewport(page);
 </script>

--- a/src/lib/PDFViewer/Page.svelte
+++ b/src/lib/PDFViewer/Page.svelte
@@ -1,15 +1,21 @@
 <!-- @component
 Render a page from a PDF document. Must be a child of a `Document` component.
  -->
+<svelte:options immutable />
+
+<!--
+	@todo Immutable could be a bad idea since it would not update 
+	for getViewport functions that are defined inline
+	when their dependencies change.
+ -->
 <script context="module" lang="ts">
+	import type { MultipleOf90 } from '$lib/utils/target_dimension.js';
 	import type { PDFDocumentProxy, PDFPageProxy } from 'pdfjs-dist/types/src/display/api';
 	import type { PageViewport } from 'pdfjs-dist/types/src/display/display_utils';
 	import { getContext, onMount } from 'svelte';
 	import type { Writable } from 'svelte/store';
 	import type PageCanvas from './PageInternals/PageCanvas.svelte';
 	import type PageSvg from './PageInternals/PageSVG.svelte';
-
-	type MultipleOf90 = 0 | 90 | 180 | 270;
 
 	function default_get_viewport(
 		page: PDFPageProxy,
@@ -50,7 +56,7 @@ Render a page from a PDF document. Must be a child of a `Document` component.
 	 * A callback invoked with the current page used to determine the viewport.
 	 * Use this if you need something more complicated than the default based on scale.
 	 */
-	export let getViewport: (page: PDFPageProxy) => PageViewport = undefined;
+	export let getViewport: (page: PDFPageProxy, rotation: MultipleOf90) => PageViewport = undefined;
 
 	/* <========================================================================================> */
 
@@ -72,10 +78,9 @@ Render a page from a PDF document. Must be a child of a `Document` component.
 
 	$: if ($current_doc) $current_doc.getPage(num).then((p) => (page = p));
 
-	$: _get_viewport =
-		getViewport ?? ((p: PDFPageProxy) => default_get_viewport(p, { scale, rotation }));
+	$: _get_viewport = getViewport ?? ((p) => default_get_viewport(p, { scale, rotation }));
 
-	$: if (page) viewport = _get_viewport(page);
+	$: if (page) viewport = _get_viewport(page, rotation);
 </script>
 
 <svelte:component

--- a/src/lib/PDFViewer/Page.svelte
+++ b/src/lib/PDFViewer/Page.svelte
@@ -29,7 +29,7 @@ Render a page from a PDF document. Must be a child of a `Document` component.
 	/**
 	 * The page number to show.
 	 */
-	export let pageNumber: number = 1;
+	export let pageNumber: number;
 	/**
 	 * The scale to show the PDF at.
 	 * @default {1}

--- a/src/lib/PDFViewer/Page.svelte
+++ b/src/lib/PDFViewer/Page.svelte
@@ -29,7 +29,7 @@ Render a page from a PDF document. Must be a child of a `Document` component.
 	/**
 	 * The page number to show.
 	 */
-	export let pageNumber: number;
+	export let num: number;
 	/**
 	 * The scale to show the PDF at.
 	 * @default {1}
@@ -70,7 +70,7 @@ Render a page from a PDF document. Must be a child of a `Document` component.
 
 	/* <========================================================================================> */
 
-	$: if ($current_doc) $current_doc.getPage(pageNumber).then((p) => (page = p));
+	$: if ($current_doc) $current_doc.getPage(num).then((p) => (page = p));
 
 	$: _get_viewport =
 		getViewport ?? ((p: PDFPageProxy) => default_get_viewport(p, { scale, rotation }));

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,7 @@
 export { default as Document } from './PDFViewer/Document.svelte';
 export { default as Page } from './PDFViewer/Page.svelte';
+export * from './utils/target_dimension.js';
+
 import * as PDFJS from 'pdfjs-dist';
 if (PDFJS.GlobalWorkerOptions) {
 	PDFJS.GlobalWorkerOptions.workerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS.version}/build/pdf.worker.min.js`;

--- a/src/lib/utils/target_dimension.ts
+++ b/src/lib/utils/target_dimension.ts
@@ -1,0 +1,18 @@
+import type { PDFPageProxy } from 'pdfjs-dist';
+import type { PageViewport } from 'pdfjs-dist/types/src/display/display_utils';
+
+export type MultipleOf90 = 0 | 90 | 180 | 270;
+
+export function preferThisWidth(width: number) {
+	return (page: PDFPageProxy, rotation: MultipleOf90 = 0): PageViewport => {
+		const tmp_width = page.getViewport({ scale: 1, rotation }).width;
+		return page.getViewport({ scale: width / tmp_width, rotation });
+	};
+}
+
+export function preferThisHeight(height: number) {
+	return (page: PDFPageProxy, rotation: MultipleOf90 = 0): PageViewport => {
+		const tmp_height = page.getViewport({ scale: 1, rotation }).height;
+		return page.getViewport({ scale: height / tmp_height, rotation });
+	};
+}

--- a/src/lib/utils/target_dimension.ts
+++ b/src/lib/utils/target_dimension.ts
@@ -3,13 +3,22 @@ import type { PageViewport } from 'pdfjs-dist/types/src/display/display_utils';
 
 export type MultipleOf90 = 0 | 90 | 180 | 270;
 
+/**
+ * A function that returns another function that returns a PageViewport with the given width.
+ *
+ * @param width - The width that you want the page to be.
+ */
 export function preferThisWidth(width: number) {
 	return (page: PDFPageProxy, rotation: MultipleOf90 = 0): PageViewport => {
 		const tmp_width = page.getViewport({ scale: 1, rotation }).width;
 		return page.getViewport({ scale: width / tmp_width, rotation });
 	};
 }
-
+/**
+ * A function that returns another function that returns a PageViewport with the given height.
+ *
+ * @param height - The height that you want the page to be.
+ */
 export function preferThisHeight(height: number) {
 	return (page: PDFPageProxy, rotation: MultipleOf90 = 0): PageViewport => {
 		const tmp_height = page.getViewport({ scale: 1, rotation }).height;

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -7,7 +7,7 @@
 		PDFJS.GlobalWorkerOptions.workerSrc = workerSrc;
 	}
 	let scale: number = 1;
-	let pageNumber: number = 1;
+	let num: number = 1;
 	let file = '/tackling-ts-preview-book.pdf';
 	let maxPages = 1;
 	let renderTextLayer: boolean;
@@ -15,7 +15,7 @@
 
 <section class="settings">
 	<input type="range" step="0.25" max="4" min="1" bind:value={scale} />
-	<input type="number" bind:value={pageNumber} step="1" min="1" max={maxPages} />
+	<input type="number" bind:value={num} step="1" min="1" max={maxPages} />
 
 	<input type="radio" value="/tackling-ts-preview-book.pdf" bind:group={file} /> Doc 1
 	<input type="radio" value="/impatient-js-preview-book.pdf" bind:group={file} /> Doc 2
@@ -31,7 +31,7 @@
 		on:loaderror={console.log}
 	>
 		<div>
-			<Page {scale} {pageNumber} {renderTextLayer} rotation={90} />
+			<Page {scale} {num} {renderTextLayer} rotation={90} />
 		</div>
 	</Document>
 {/if}

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -6,7 +6,7 @@
 	if (PDFJS.GlobalWorkerOptions) {
 		PDFJS.GlobalWorkerOptions.workerSrc = workerSrc;
 	}
-	let zoomLevel: number = 1;
+	let scale: number = 1;
 	let pageNumber: number = 1;
 	let file = '/tackling-ts-preview-book.pdf';
 	let maxPages = 1;
@@ -14,7 +14,7 @@
 </script>
 
 <section class="settings">
-	<input type="range" step="0.25" max="4" min="1" bind:value={zoomLevel} />
+	<input type="range" step="0.25" max="4" min="1" bind:value={scale} />
 	<input type="number" bind:value={pageNumber} step="1" min="1" max={maxPages} />
 
 	<input type="radio" value="/tackling-ts-preview-book.pdf" bind:group={file} /> Doc 1
@@ -31,7 +31,7 @@
 		on:loaderror={console.log}
 	>
 		<div>
-			<Page {zoomLevel} {pageNumber} {renderTextLayer} rotation={90}/>
+			<Page {scale} {pageNumber} {renderTextLayer} rotation={90} />
 		</div>
 	</Document>
 {/if}

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Document, Page, PDFJS } from 'svelte-pdfjs';
+	import { Document, MultipleOf90, Page, PDFJS, preferThisHeight } from 'svelte-pdfjs';
 	import workerSrc from 'pdfjs-dist/build/pdf.worker.min.js?url';
 	import { browser } from '$app/env';
 
@@ -11,6 +11,12 @@
 	let file = '/tackling-ts-preview-book.pdf';
 	let maxPages = 1;
 	let renderTextLayer: boolean;
+	let targetHeight = 500;
+	let rotation: MultipleOf90 = 0;
+
+	const handleSelect = (e) => {
+		rotation = parseInt(e.currentTarget.value) as MultipleOf90;
+	};
 </script>
 
 <section class="settings">
@@ -22,6 +28,13 @@
 	<input type="radio" bind:group={file} value="/yadayada.pdf" /> Doc 3 (doesn't exist)
 
 	<input type="checkbox" bind:checked={renderTextLayer} /> Render text layer
+	<input type="range" step="20" max="700" min="300" bind:value={targetHeight} />
+	<select on:change={handleSelect}>
+		<option>0</option>
+		<option>90</option>
+		<option>180</option>
+		<option>270</option>
+	</select>
 </section>
 
 {#if browser}
@@ -31,7 +44,13 @@
 		on:loaderror={console.log}
 	>
 		<div>
-			<Page {scale} {num} {renderTextLayer} rotation={90} />
+			<Page
+				{scale}
+				{num}
+				{renderTextLayer}
+				{rotation}
+				getViewport={preferThisHeight(targetHeight)}
+			/>
 		</div>
 	</Document>
 {/if}

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -31,7 +31,7 @@
 		on:loaderror={console.log}
 	>
 		<div>
-			<Page {zoomLevel} {pageNumber} {renderTextLayer} />
+			<Page {zoomLevel} {pageNumber} {renderTextLayer} rotation={90}/>
 		</div>
 	</Document>
 {/if}


### PR DESCRIPTION
Previously page took props `targetHeight` and `targetWidth` props to allow rendering the page at a custom pixel height/width.

Instead of that, page will now take a getViewport prop, which will be a callback of type

```ts
    type getViewport = (page: PDFPageProxy, rotation: MultipleOf90) => PageViewport;
```

Inside the callback, users can derive a `PageViewport` object from the provided page and return it.

An implementation of getViewport that will only consider scale will be used by default. The package will also export some helpers to deal with some common cases.

Hopefully this should provide a balance of simplicity and the freedom to do powerful stuff.