### PR TITLE
feat: add `pageloadsuccess` and `pageloaderror` events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # svelte-pdfjs
 
+## 0.6.2
+
+### Patch Changes
+
+- feat: add pagerendersuccess and pagerendererror events to Page and PageCanvas
+
 ## 0.6.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-pdfjs",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/src/lib/PDFViewer/Page.svelte
+++ b/src/lib/PDFViewer/Page.svelte
@@ -74,5 +74,7 @@ Render a page from a PDF document. Must be a child of a `Document` component.
 		{page}
 		{viewport}
 		render_text_layer={renderer === 'canvas' ? renderTextLayer : false}
+		on:pageloadsuccess
+		on:pageloaderror
 	/>
 {/await}

--- a/src/lib/PDFViewer/Page.svelte
+++ b/src/lib/PDFViewer/Page.svelte
@@ -51,6 +51,11 @@ Render a page from a PDF document. Must be a child of a `Document` component.
 	export let getViewport: CalcViewport | undefined = undefined;
 	// #endregion props
 
+	interface $$Events {
+		pagerendersuccess: CustomEvent<PDFPageProxy>;
+		pagerendererror: CustomEvent<unknown>;
+	}
+
 	onDestroy(() => page?.cleanup());
 
 	const current_doc: Writable<PDFDocumentProxy> = getContext('svelte_pdfjs_doc');

--- a/src/lib/PDFViewer/Page.svelte
+++ b/src/lib/PDFViewer/Page.svelte
@@ -74,7 +74,7 @@ Render a page from a PDF document. Must be a child of a `Document` component.
 		{page}
 		{viewport}
 		render_text_layer={renderer === 'canvas' ? renderTextLayer : false}
-		on:pageloadsuccess
-		on:pageloaderror
+		on:pagerendersuccess
+		on:pagerendererror
 	/>
 {/await}

--- a/src/lib/PDFViewer/PageInternals/PageCanvas.svelte
+++ b/src/lib/PDFViewer/PageInternals/PageCanvas.svelte
@@ -12,7 +12,7 @@
 	export let page: PDFPageProxy;
 	export let viewport: PageViewport;
 	export let render_text_layer: boolean;
-	export let canvasStyles: string;
+	export let canvasStyles = '';
 
 	let canvas: HTMLCanvasElement;
 
@@ -28,10 +28,10 @@
 
 		try {
 			await render_task.promise;
-			dispatch('pageloadsuccess', page);
+			dispatch('pagerendersuccess', page);
 		} catch (err) {
 			if (!(err instanceof RenderingCancelledException)) {
-				dispatch('pageloaderror', err);
+				dispatch('pagerendererror', err);
 				throw err;
 			}
 		}
@@ -45,7 +45,7 @@
 		bind:this={canvas}
 		width={viewport?.width}
 		height={viewport?.height}
-		{style}
+		style={canvasStyles}
 	/>{#if render_text_layer}
 		<TextLayer {page} {viewport} />
 	{/if}

--- a/src/lib/PDFViewer/PageInternals/PageCanvas.svelte
+++ b/src/lib/PDFViewer/PageInternals/PageCanvas.svelte
@@ -7,7 +7,10 @@
 </script>
 
 <script lang="ts">
-	const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher<{
+		pagerendersuccess: PDFPageProxy;
+		pagerendererror: unknown;
+	}>();
 
 	export let page: PDFPageProxy;
 	export let viewport: PageViewport;

--- a/src/lib/PDFViewer/PageInternals/PageCanvas.svelte
+++ b/src/lib/PDFViewer/PageInternals/PageCanvas.svelte
@@ -1,13 +1,18 @@
-<script lang="ts">
+<script lang="ts" context="module">
 	import { RenderingCancelledException } from 'pdfjs-dist';
 	import type { PDFPageProxy, RenderTask } from 'pdfjs-dist';
 	import type { PageViewport } from 'pdfjs-dist/types/src/display/display_utils.js';
-	import { tick } from 'svelte';
+	import { createEventDispatcher, tick } from 'svelte';
 	import TextLayer from './TextLayer.svelte';
+</script>
+
+<script lang="ts">
+	const dispatch = createEventDispatcher();
 
 	export let page: PDFPageProxy;
 	export let viewport: PageViewport;
 	export let render_text_layer: boolean;
+	export let style: string;
 
 	let canvas: HTMLCanvasElement;
 
@@ -23,7 +28,9 @@
 
 		try {
 			await render_task.promise;
+			dispatch('pageloadsuccess', page);
 		} catch (err) {
+			dispatch('pageloaderror', err);
 			if (!(err instanceof RenderingCancelledException)) throw err;
 		}
 	}
@@ -36,6 +43,7 @@
 		bind:this={canvas}
 		width={viewport?.width}
 		height={viewport?.height}
+		{style}
 	/>{#if render_text_layer}
 		<TextLayer {page} {viewport} />
 	{/if}

--- a/src/lib/PDFViewer/PageInternals/PageCanvas.svelte
+++ b/src/lib/PDFViewer/PageInternals/PageCanvas.svelte
@@ -30,8 +30,10 @@
 			await render_task.promise;
 			dispatch('pageloadsuccess', page);
 		} catch (err) {
-			dispatch('pageloaderror', err);
-			if (!(err instanceof RenderingCancelledException)) throw err;
+			if (!(err instanceof RenderingCancelledException)) {
+				dispatch('pageloaderror', err);
+				throw err;
+			}
 		}
 	}
 

--- a/src/lib/PDFViewer/PageInternals/PageCanvas.svelte
+++ b/src/lib/PDFViewer/PageInternals/PageCanvas.svelte
@@ -12,7 +12,7 @@
 	export let page: PDFPageProxy;
 	export let viewport: PageViewport;
 	export let render_text_layer: boolean;
-	export let style: string;
+	export let canvasStyles: string;
 
 	let canvas: HTMLCanvasElement;
 


### PR DESCRIPTION
closes https://github.com/gtm-nayan/svelte-pdfjs/issues/12

Dispatches the `pageloadsuccess` custom event once the `PageCanvas` render task has completed successfully.
Failed page loads emit the `pageloaderror` custom event.